### PR TITLE
fixing case insensitive import collision

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
+	"github.com/sirupsen/logrus"
 	"github.com/techjacker/diffence"
 )
 

--- a/log.go
+++ b/log.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	elastic "gopkg.in/olivere/elastic.v5"
 	elogrus "gopkg.in/sohlich/elogrus.v2"
 

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 	"path"
 	"runtime"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
+	"github.com/sirupsen/logrus"
 	"github.com/techjacker/diffence"
 )
 


### PR DESCRIPTION
The author of `logrus` changed the name of its account so the dependency  was broken sirupsen/logrus#543 